### PR TITLE
Replace the typo "Reagir" to "React"

### DIFF
--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -30,7 +30,7 @@ A autenticação e a autorização do usuário podem ser usadas com SPAs angular
 dotnet new angular -o <output_directory_name> -au Individual
 ```
 
-**Reagir**:
+**React**:
 
 ```dotnetcli
 dotnet new react -o <output_directory_name> -au Individual
@@ -192,8 +192,8 @@ services.Configure<JwtBearerOptions>(
     IdentityServerJwtConstants.IdentityServerJwtBearerScheme,
     options =>
     {
-        var onTokenValidated = options.Events.OnTokenValidated;       
-        
+        var onTokenValidated = options.Events.OnTokenValidated;
+
         options.Events.OnTokenValidated = async context =>
         {
             await onTokenValidated(context);


### PR DESCRIPTION
This is a typo in the doc. The word should be "React", as the frontend
library and not the verb.
